### PR TITLE
fix(schemas): updated patterns

### DIFF
--- a/v1.0.0/schemas/organisation_v1_.0.0.schema.json
+++ b/v1.0.0/schemas/organisation_v1_.0.0.schema.json
@@ -9,7 +9,7 @@
     "properties": {
         "$schema": {
             "type": "string",
-            "pattern": "^.*_v\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.schema\\.json$"
+            "pattern": "^.*organisation_v\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.schema\\.json$"
         },
         "ref_name": { "$ref": "id_v1.0.0.schema.json#/$defs/NameId" },
         "ref_teams": {

--- a/v1.0.0/schemas/team_v1.0.0_schema.json
+++ b/v1.0.0/schemas/team_v1.0.0_schema.json
@@ -9,7 +9,7 @@
     "properties": {
         "$schema": {
             "type": "string",
-            "pattern": "^.*_v\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.schema\\.json$"
+            "pattern": "^.*team_v\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.schema\\.json$"
         },
         "ref_name": { "$ref": "id_v1.0.0.schema.json#/$defs/NameId" },
         "ref_members": {


### PR DESCRIPTION
Schema patterns were missing their respective type name.

organisations changes from
`"pattern": "^.*_v\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.schema\\.json$"`
to
`"pattern": "^.*organisation_v\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.schema\\.json$"`
for example.